### PR TITLE
add another variable for ARGS and OPTS inteded for dockerfiles

### DIFF
--- a/8-jre/Dockerfile
+++ b/8-jre/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER Molindo GmbH <build@molindo.at>
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
+ENV DEFAULT_JAVA_OPTS ""
+ENV DEFAULT_JAVA_ARGS ""
 ENV JAVA_OPTS ""
 ENV JAVA_ARGS ""
 
@@ -19,9 +21,9 @@ RUN set -x \
 		openjdk-8-jre-headless \
 		ca-certificates-java \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& echo '#!/bin/sh\nexec /usr/bin/java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap $JAVA_OPTS "$@" $JAVA_ARGS' > /usr/local/bin/java.sh \
+	&& echo '#!/bin/sh\nexec /usr/bin/java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap $DEFAULT_JAVA_OPTS $JAVA_OPTS "$@" $DEFAULT_JAVA_ARGS $JAVA_ARGS' > /usr/local/bin/java.sh \
 	&& chmod +x /usr/local/bin/* \
-	&& /usr/local/bin/java.sh -version
+	&& /usr/local/bin/java.sh -XshowSettings:vm -version
 
 ENTRYPOINT ["/usr/local/bin/java.sh"]
 CMD ["-version"]

--- a/8-jre/alpine/Dockerfile
+++ b/8-jre/alpine/Dockerfile
@@ -4,14 +4,16 @@ MAINTAINER Molindo GmbH <build@molindo.at>
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
+ENV DEFAULT_JAVA_OPTS ""
+ENV DEFAULT_JAVA_ARGS ""
 ENV JAVA_OPTS ""
 ENV JAVA_ARGS ""
 
 RUN set -x \
 	&& apk add --no-cache curl bash wget gnupg openjdk8-jre \
-	&& echo -e '#!/bin/sh\nexec /usr/bin/java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap $JAVA_OPTS "$@" $JAVA_ARGS' > /usr/local/bin/java.sh \
+	&& echo -e '#!/bin/sh\nexec /usr/bin/java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap $DEFAULT_JAVA_OPTS $JAVA_OPTS "$@" $DEFAULT_JAVA_ARGS $JAVA_ARGS' > /usr/local/bin/java.sh \
 	&& chmod +x /usr/local/bin/* \
-	&& /usr/local/bin/java.sh -version
+	&& /usr/local/bin/java.sh -XshowSettings:vm -version
 
 ENTRYPOINT ["/usr/local/bin/java.sh"]
 CMD ["-version"]

--- a/9-jre/Dockerfile
+++ b/9-jre/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER Molindo GmbH <build@molindo.at>
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
+ENV DEFAULT_JAVA_OPTS ""
+ENV DEFAULT_JAVA_ARGS ""
 ENV JAVA_OPTS ""
 ENV JAVA_ARGS ""
 
@@ -20,9 +22,9 @@ RUN set -x \
 		openjdk-9-jre-headless \
 		ca-certificates-java \
 	&& rm -rf /var/lib/apt/lists/* \
-	&& echo '#!/bin/sh\nexec /usr/bin/java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap $JAVA_OPTS "$@" $JAVA_ARGS' > /usr/local/bin/java.sh \
+	&& echo '#!/bin/sh\nexec /usr/bin/java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap $DEFAULT_JAVA_OPTS $JAVA_OPTS "$@" $DEFAULT_JAVA_ARGS $JAVA_ARGS' > /usr/local/bin/java.sh \
 	&& chmod +x /usr/local/bin/* \
-	&& /usr/local/bin/java.sh -version
+	&& /usr/local/bin/java.sh -XshowSettings:vm -version
 
 ENTRYPOINT ["/usr/local/bin/java.sh"]
 CMD ["-version"]


### PR DESCRIPTION
the idea is to define `DEFAULT_JAVA_OPTS` in `Dockerfile` while allowing to add more depending on the environment without overriding all of them